### PR TITLE
Migrate to RxJava 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ allprojects {
 2. Add a dependency to ***RxAdapter***
 ```
 dependencies {
-	implementation 'com.github.marcbaldwin:RxAdapter:1.12.0'
+	implementation 'com.github.marcbaldwin:RxAdapter:2.0.0'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$rootProject.ext.kotlin_version"
     implementation "com.android.support:appcompat-v7:$android_support_version"
     implementation "com.android.support:design:$android_support_version"
-    implementation 'io.reactivex:rxjava:1.3.4'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.13'
 
     implementation project(':rxadapter')
 

--- a/app/src/main/java/xyz/marcb/rxadapter/app/MainActivity.kt
+++ b/app/src/main/java/xyz/marcb/rxadapter/app/MainActivity.kt
@@ -8,17 +8,19 @@ import android.support.v7.widget.RecyclerView
 import android.support.v7.widget.Toolbar
 import android.view.View
 import android.widget.TextView
-import rx.Observable
-import rx.subjects.BehaviorSubject
+import io.reactivex.Observable
+import io.reactivex.subjects.BehaviorSubject
+import xyz.marcb.rxadapter.Optional
 import xyz.marcb.rxadapter.RxAdapter
 import java.util.*
-import java.util.Collections.emptyList
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var listView: RecyclerView
 
-    private val items = BehaviorSubject.create<List<Date>>(emptyList<Date>())
+    private val items = BehaviorSubject.create<List<Date>>().apply {
+        onNext(emptyList())
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,9 +56,9 @@ class MainActivity : AppCompatActivity() {
             }
 
             // Nullable item
-            optionalItem<String, HeaderViewHolder>(HeaderViewHolder::class.java, Observable.just(null)) {
+            optionalItem<String, HeaderViewHolder>(HeaderViewHolder::class.java, Observable.just(Optional.None)) {
                 binder = { _->
-                    title.text = "Nulls are allowed"
+                    title.text = "None is allowed"
                 }
             }
         }

--- a/rxadapter/build.gradle
+++ b/rxadapter/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$rootProject.ext.kotlin_version"
     implementation "com.android.support:appcompat-v7:$android_support_version"
     implementation "com.android.support:design:$android_support_version"
-    implementation 'io.reactivex:rxjava:1.3.4'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.13'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-all:1.10.19'

--- a/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/AdapterPart.kt
+++ b/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/AdapterPart.kt
@@ -1,7 +1,7 @@
 package xyz.marcb.rxadapter
 
 import android.support.v7.widget.RecyclerView
-import rx.Observable
+import io.reactivex.Observable
 
 interface AdapterPart {
 

--- a/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/Item.kt
+++ b/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/Item.kt
@@ -1,13 +1,13 @@
 package xyz.marcb.rxadapter
 
 import android.support.v7.widget.RecyclerView
-import rx.Observable
-import java.util.*
+import io.reactivex.Observable
+import java.util.UUID
 
 class Item<I, VH>(
         private val vhClass: Class<VH>,
         private val item: Observable<I>
-) : AdapterPart where I: Any?, VH: RecyclerView.ViewHolder {
+) : AdapterPart where I: Any, VH: RecyclerView.ViewHolder {
 
     var binder: (VH.(I) -> Unit)? = null
     var onClick: (VH.(I) -> Unit)? = null

--- a/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/Items.kt
+++ b/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/Items.kt
@@ -1,8 +1,8 @@
 package xyz.marcb.rxadapter
 
 import android.support.v7.widget.RecyclerView
-import rx.Observable
 import java.util.*
+import io.reactivex.Observable
 
 class Items<I, VH>(
         private val vhClass: Class<VH>,

--- a/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/Optional.kt
+++ b/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/Optional.kt
@@ -1,0 +1,20 @@
+package xyz.marcb.rxadapter
+
+sealed class Optional<out T> {
+
+    data class Some<out T>(val item: T): Optional<T>()
+    object None: Optional<Nothing>()
+
+    open val value: T?
+        get() = when(this) {
+            is Some -> item
+            is None -> null
+        }
+
+}
+
+fun <T> T?.asOptional() =
+        if (this != null)
+            Optional.Some(this)
+        else
+            Optional.None

--- a/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/OptionalItem.kt
+++ b/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/OptionalItem.kt
@@ -1,12 +1,12 @@
 package xyz.marcb.rxadapter
 
 import android.support.v7.widget.RecyclerView
-import rx.Observable
-import java.util.*
+import io.reactivex.Observable
+import java.util.UUID
 
 class OptionalItem<I, VH>(
         private val vhClass: Class<VH>,
-        private val item: Observable<I?>
+        private val item: Observable<Optional<I>>
 ) : AdapterPart where I: Any, VH: RecyclerView.ViewHolder {
 
     var binder: (VH.(I) -> Unit)? = null
@@ -16,6 +16,10 @@ class OptionalItem<I, VH>(
 
     override val snapshots: Observable<AdapterPartSnapshot> get() =
         item.map { item ->
-            item?.let { Snapshot(vhClass, listOf(it), listOf(id), binder, onClick) } ?: EmptySnapshot()
+            when (item) {
+                is Optional.Some -> Snapshot(vhClass, listOf(item.item), listOf(id), binder, onClick)
+                is Optional.None -> EmptySnapshot()
+            }
         }
+
 }

--- a/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/RxAdapter.kt
+++ b/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/RxAdapter.kt
@@ -6,7 +6,8 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import rx.Subscription
+import io.reactivex.disposables.Disposable
+import org.reactivestreams.Subscription
 
 open class RxAdapter: RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
@@ -16,7 +17,7 @@ open class RxAdapter: RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private var snapshot: AdapterPartSnapshot = EmptySnapshot()
     private var adapterCount = 0
-    private var subscription: Subscription? = null
+    private var subscription: Disposable? = null
 
     inline fun section(init: Section.() -> Unit): Section {
         val section = Section()
@@ -80,7 +81,7 @@ open class RxAdapter: RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private fun onAdapterCountChange() {
         when (adapterCount) {
             0 -> {
-                subscription?.unsubscribe()
+                subscription?.dispose()
                 subscription = null
             }
             else -> {

--- a/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/RxViewHolder.kt
+++ b/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/RxViewHolder.kt
@@ -2,11 +2,11 @@ package xyz.marcb.rxadapter
 
 import android.support.v7.widget.RecyclerView
 import android.view.View
-import rx.subscriptions.CompositeSubscription
+import io.reactivex.disposables.CompositeDisposable
 
 open class RxViewHolder(view: View) : RecyclerView.ViewHolder(view) {
 
-    val subscriptions = CompositeSubscription()
+    val subscriptions = CompositeDisposable()
 
     open fun recycle() = subscriptions.clear()
 }

--- a/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/Section.kt
+++ b/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/Section.kt
@@ -1,7 +1,7 @@
 package xyz.marcb.rxadapter
 
 import android.support.v7.widget.RecyclerView
-import rx.Observable
+import io.reactivex.Observable
 
 class Section: AdapterPart {
 
@@ -19,13 +19,13 @@ class Section: AdapterPart {
     }
 
     inline fun <I, VH> item(vhClass: Class<VH>, item: Observable<I>, init: Item<I, VH>.() -> Unit): Item<I, VH>
-            where I: Any?, VH: RecyclerView.ViewHolder {
+            where I: Any, VH: RecyclerView.ViewHolder {
         val part = add(Item(vhClass, item))
         init.invoke(part)
         return part
     }
 
-    inline fun <I, VH> optionalItem(vhClass: Class<VH>, item: Observable<I?>, init: OptionalItem<I, VH>.() -> Unit): OptionalItem<I, VH>
+    inline fun <I, VH> optionalItem(vhClass: Class<VH>, item: Observable<Optional<I>>, init: OptionalItem<I, VH>.() -> Unit): OptionalItem<I, VH>
             where I: Any, VH: RecyclerView.ViewHolder {
         val part = add(OptionalItem(vhClass, item))
         init.invoke(part)

--- a/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/StaticItem.kt
+++ b/rxadapter/src/main/kotlin/xyz/marcb/rxadapter/StaticItem.kt
@@ -1,8 +1,8 @@
 package xyz.marcb.rxadapter
 
 import android.support.v7.widget.RecyclerView
-import rx.Observable
-import java.util.*
+import io.reactivex.Observable
+import java.util.UUID
 
 class StaticItem<VH>(private val vhClass: Class<VH>)
     : AdapterPart where VH : RecyclerView.ViewHolder {

--- a/rxadapter/src/test/kotlin/xyz/marcb/rxadapter/CombineTests.kt
+++ b/rxadapter/src/test/kotlin/xyz/marcb/rxadapter/CombineTests.kt
@@ -1,12 +1,13 @@
 package xyz.marcb.rxadapter
 
+import io.reactivex.Observable
+import io.reactivex.observers.TestObserver
+import io.reactivex.subscribers.TestSubscriber
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
-import rx.Observable
-import rx.observers.TestSubscriber
 import kotlin.test.expect
 
 class CombineTests {
@@ -17,7 +18,7 @@ class CombineTests {
     @Mock private lateinit var adapterPartSnapshotA: AdapterPartSnapshot
     @Mock private lateinit var adapterPartSnapshotB: AdapterPartSnapshot
 
-    private lateinit var snapshotSubscriber: TestSubscriber<AdapterPartSnapshot>
+    private lateinit var snapshotObserver: TestObserver<AdapterPartSnapshot>
 
     @Before fun setUp() {
         MockitoAnnotations.initMocks(this)
@@ -29,34 +30,34 @@ class CombineTests {
         Mockito.`when`(adapterPartSnapshotA.itemCount).thenReturn(1)
         Mockito.`when`(adapterPartSnapshotB.itemCount).thenReturn(2)
 
-        snapshotSubscriber = TestSubscriber()
+        snapshotObserver = TestObserver()
     }
 
     @Test fun includesSnapshotsWithNoVisibilityObservable() {
-        listOf(adapterPartA, adapterPartB).combine().subscribe(snapshotSubscriber)
+        listOf(adapterPartA, adapterPartB).combine().subscribe(snapshotObserver)
 
-        expect(3) { snapshotSubscriber.onNextEvents[0].itemCount }
+        expect(3) { snapshotObserver.values()[0].itemCount }
     }
 
     @Test fun includesVisibleSnapshots() {
         Mockito.`when`(adapterPartB.visible).thenReturn(Observable.just(true))
-        listOf(adapterPartA, adapterPartB).combine().subscribe(snapshotSubscriber)
+        listOf(adapterPartA, adapterPartB).combine().subscribe(snapshotObserver)
 
-        expect(3) { snapshotSubscriber.onNextEvents[0].itemCount }
+        expect(3) { snapshotObserver.values()[0].itemCount }
     }
 
     @Test fun ignoresHiddenSnapshots() {
         Mockito.`when`(adapterPartB.visible).thenReturn(Observable.just(false))
-        listOf(adapterPartA, adapterPartB).combine().subscribe(snapshotSubscriber)
+        listOf(adapterPartA, adapterPartB).combine().subscribe(snapshotObserver)
 
-        expect(1) { snapshotSubscriber.onNextEvents[0].itemCount }
+        expect(1) { snapshotObserver.values()[0].itemCount }
     }
 
     @Test fun emitsNewSnapshotWhenVisibilityChanges() {
         Mockito.`when`(adapterPartB.visible).thenReturn(Observable.just(false, true))
-        listOf(adapterPartA, adapterPartB).combine().subscribe(snapshotSubscriber)
+        listOf(adapterPartA, adapterPartB).combine().subscribe(snapshotObserver)
 
-        expect(1) { snapshotSubscriber.onNextEvents[0].itemCount }
-        expect(3) { snapshotSubscriber.onNextEvents[1].itemCount }
+        expect(1) { snapshotObserver.values()[0].itemCount }
+        expect(3) { snapshotObserver.values()[1].itemCount }
     }
 }

--- a/rxadapter/src/test/kotlin/xyz/marcb/rxadapter/ItemTests.kt
+++ b/rxadapter/src/test/kotlin/xyz/marcb/rxadapter/ItemTests.kt
@@ -1,63 +1,63 @@
 package xyz.marcb.rxadapter
 
+import io.reactivex.Observable
+import io.reactivex.observers.TestObserver
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
-import rx.Observable
-import rx.observers.TestSubscriber
 import kotlin.test.expect
 
 class ItemTests {
 
     @Mock private lateinit var viewHolder: HeaderViewHolder
-    private val snapshotSubscriber = TestSubscriber<AdapterPartSnapshot>()
-    private lateinit var item: Item<String?, HeaderViewHolder>
+    private val snapshotObserver = TestObserver<AdapterPartSnapshot>()
+    private lateinit var item: Item<Optional<String>, HeaderViewHolder>
 
     @Before fun setUp() {
         MockitoAnnotations.initMocks(this)
     }
 
-    private fun createWith(observable: Observable<String?>) {
+    private fun createWith(observable: Observable<Optional<String>>) {
         item = Item(HeaderViewHolder::class.java, observable).apply {
-            binder = { item -> bind(item) }
+            binder = { item -> bind(item.value) }
         }
-        item.snapshots.subscribe(snapshotSubscriber)
+        item.snapshots.subscribe(snapshotObserver)
     }
 
     @Test fun itemCountIsOneForNonNullValue() {
-        createWith(Observable.just("A"))
-        expect(1) { snapshotSubscriber.onNextEvents[0].itemCount }
+        createWith(Observable.just("A".asOptional()))
+        expect(1) { snapshotObserver.values()[0].itemCount }
     }
 
     @Test fun itemCountIsOneForNullValue() {
-        createWith(Observable.just(null))
-        expect(1) { snapshotSubscriber.onNextEvents[0].itemCount }
+        createWith(Observable.just(Optional.None))
+        expect(1) { snapshotObserver.values()[0].itemCount }
     }
 
     @Test fun viewHolderClassForNonNullValue() {
-        createWith(Observable.just("A"))
-        val snapshot = snapshotSubscriber.onNextEvents[0]
+        createWith(Observable.just("A".asOptional()))
+        val snapshot = snapshotObserver.values()[0]
         expect(HeaderViewHolder::class.java) { snapshot.viewHolderClass(0) }
     }
 
     @Test fun viewHolderClassForNullValue() {
-        createWith(Observable.just(null))
-        val snapshot = snapshotSubscriber.onNextEvents[0]
+        createWith(Observable.just(Optional.None))
+        val snapshot = snapshotObserver.values()[0]
         expect(HeaderViewHolder::class.java) { snapshot.viewHolderClass(0) }
     }
 
     @Test fun binderIsInvokedForNonNullValue() {
-        createWith(Observable.just("A"))
-        val snapshot = snapshotSubscriber.onNextEvents[0]
+        createWith(Observable.just("A".asOptional()))
+        val snapshot = snapshotObserver.values()[0]
         snapshot.bind(viewHolder, index = 0)
         Mockito.verify(viewHolder).bind("A")
     }
 
     @Test fun binderIsInvokedForNullValue() {
-        createWith(Observable.just(null))
-        val snapshot = snapshotSubscriber.onNextEvents[0]
+        createWith(Observable.just(Optional.None))
+        val snapshot = snapshotObserver.values()[0]
         snapshot.bind(viewHolder, index = 0)
         Mockito.verify(viewHolder).bind(null)
     }

--- a/rxadapter/src/test/kotlin/xyz/marcb/rxadapter/ItemsTests.kt
+++ b/rxadapter/src/test/kotlin/xyz/marcb/rxadapter/ItemsTests.kt
@@ -1,18 +1,19 @@
 package xyz.marcb.rxadapter
 
+import android.system.Os.bind
+import io.reactivex.Observable
+import io.reactivex.observers.TestObserver
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
-import rx.Observable
-import rx.observers.TestSubscriber
 import kotlin.test.expect
 
 internal class ItemsTests {
 
     @Mock private lateinit var viewHolder: HeaderViewHolder
-    private val snapshotSubscriber = TestSubscriber<AdapterPartSnapshot>()
+    private val snapshotObserver = TestObserver<AdapterPartSnapshot>()
     private lateinit var items: Items<String, HeaderViewHolder>
 
     @Before fun setUp() {
@@ -20,23 +21,23 @@ internal class ItemsTests {
         items = Items(HeaderViewHolder::class.java, Observable.just(listOf("1", "2", "3"))).apply {
             binder = { item -> bind(item) }
         }
-        items.snapshots.subscribe(snapshotSubscriber)
+        items.snapshots.subscribe(snapshotObserver)
     }
 
     @Test fun itemCount() {
-        val snapshot = snapshotSubscriber.onNextEvents[0]
+        val snapshot = snapshotObserver.values()[0]
         expect(3) { snapshot.itemCount }
     }
 
     @Test fun viewHolderClass() {
-        val snapshot = snapshotSubscriber.onNextEvents[0]
+        val snapshot = snapshotObserver.values()[0]
         expect(HeaderViewHolder::class.java) { snapshot.viewHolderClass(0) }
         expect(HeaderViewHolder::class.java) { snapshot.viewHolderClass(1) }
         expect(HeaderViewHolder::class.java) { snapshot.viewHolderClass(2) }
     }
 
     @Test fun binderIsInvoked() {
-        val snapshot = snapshotSubscriber.onNextEvents[0]
+        val snapshot = snapshotObserver.values()[0]
 
         snapshot.bind(viewHolder, index = 0)
         Mockito.verify(viewHolder).bind("1")

--- a/rxadapter/src/test/kotlin/xyz/marcb/rxadapter/OptionalItemTests.kt
+++ b/rxadapter/src/test/kotlin/xyz/marcb/rxadapter/OptionalItemTests.kt
@@ -1,50 +1,50 @@
 package xyz.marcb.rxadapter
 
+import io.reactivex.Observable
+import io.reactivex.observers.TestObserver
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
-import rx.Observable
-import rx.observers.TestSubscriber
 import kotlin.test.expect
 
 class OptionalItemTests {
 
     @Mock private lateinit var viewHolder: HeaderViewHolder
-    private val snapshotSubscriber = TestSubscriber<AdapterPartSnapshot>()
+    private val snapshotObserver = TestObserver<AdapterPartSnapshot>()
     private lateinit var item: OptionalItem<String, HeaderViewHolder>
 
     @Before fun setUp() {
         MockitoAnnotations.initMocks(this)
     }
 
-    private fun createWith(observable: Observable<String?>) {
+    private fun createWith(observable: Observable<Optional<String>>) {
         item = OptionalItem(HeaderViewHolder::class.java, observable).apply {
             binder = { item -> bind(item) }
         }
-        item.snapshots.subscribe(snapshotSubscriber)
+        item.snapshots.subscribe(snapshotObserver)
     }
 
     @Test fun itemCountIsOneIfPresent() {
-        createWith(Observable.just("A"))
-        expect(1) { snapshotSubscriber.onNextEvents[0].itemCount }
+        createWith(Observable.just("A".asOptional()))
+        expect(1) { snapshotObserver.values()[0].itemCount }
     }
 
     @Test fun itemCountIsZeroIfNotPresent() {
-        createWith(Observable.just(null))
-        expect(0) { snapshotSubscriber.onNextEvents[0].itemCount }
+        createWith(Observable.just(Optional.None))
+        expect(0) { snapshotObserver.values()[0].itemCount }
     }
 
     @Test fun viewHolderClass() {
-        createWith(Observable.just("A"))
-        val snapshot = snapshotSubscriber.onNextEvents[0]
+        createWith(Observable.just("A".asOptional()))
+        val snapshot = snapshotObserver.values()[0]
         expect(HeaderViewHolder::class.java) { snapshot.viewHolderClass(0) }
     }
 
     @Test fun binderIsInvoked() {
-        createWith(Observable.just("A"))
-        val snapshot = snapshotSubscriber.onNextEvents[0]
+        createWith(Observable.just("A".asOptional()))
+        val snapshot = snapshotObserver.values()[0]
         snapshot.bind(viewHolder, index = 0)
         Mockito.verify(viewHolder).bind("A")
     }

--- a/rxadapter/src/test/kotlin/xyz/marcb/rxadapter/StaticItemTests.kt
+++ b/rxadapter/src/test/kotlin/xyz/marcb/rxadapter/StaticItemTests.kt
@@ -1,17 +1,17 @@
 package xyz.marcb.rxadapter
 
+import io.reactivex.observers.TestObserver
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
-import rx.observers.TestSubscriber
 import kotlin.test.expect
 
 internal class StaticItemTests {
 
     @Mock private lateinit var viewHolder: HeaderViewHolder
-    private val snapshotSubscriber = TestSubscriber<AdapterPartSnapshot>()
+    private val snapshotObserver = TestObserver<AdapterPartSnapshot>()
     private lateinit var item: StaticItem<HeaderViewHolder>
 
     @Before fun setUp() {
@@ -22,8 +22,8 @@ internal class StaticItemTests {
     }
 
     private fun subscribeTakeFirst(): AdapterPartSnapshot {
-        item.snapshots.subscribe(snapshotSubscriber)
-        return snapshotSubscriber.onNextEvents[0]
+        item.snapshots.subscribe(snapshotObserver)
+        return snapshotObserver.values()[0]
     }
 
     @Test fun itemCountIsAlwaysOne() {


### PR DESCRIPTION
The main work here was making `OptionItem` use the newly included `Optional` utility class because RxJava 2 does not allow Observables of null values.